### PR TITLE
Fix distributed trace

### DIFF
--- a/cmd/saga/start/app/app.go
+++ b/cmd/saga/start/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/start/app/service"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/start/app/temporal"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/logging"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/tracing"
 	"go.uber.org/fx"
 )
 
@@ -13,4 +14,7 @@ var Module = fx.Options(
 	connect.Module,
 	logging.Module,
 	service.Module,
+	tracing.CreateModule(tracing.ModuleOptions{
+		ServiceName: "temporal-starter",
+	}),
 )

--- a/cmd/saga/start/app/connect/connect.go
+++ b/cmd/saga/start/app/connect/connect.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/bufbuild/connect-go"
 	grpchealth "github.com/bufbuild/connect-grpchealth-go"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/start/service"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/internal/idl/com/teachingstrategies/temporal/v1beta1/temporalv1beta1connect"
+	pkgConnect "github.com/kevinmichaelchen/temporal-saga-grpc/pkg/connect"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/cors"
 	"github.com/sethvargo/go-envconfig"
 	"github.com/sirupsen/logrus"
@@ -75,6 +77,7 @@ func RegisterServer(mux *http.ServeMux, svc *service.Service) {
 	// Register our Connect-Go server
 	path, handler := temporalv1beta1connect.NewTemporalServiceHandler(
 		svc,
+		connect.WithInterceptors(pkgConnect.UnaryInterceptors()...),
 	)
 	checker := grpchealth.NewStaticChecker(
 		// protoc-gen-connect-go generates package-level constants

--- a/cmd/saga/start/app/temporal/temporal.go
+++ b/cmd/saga/start/app/temporal/temporal.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"context"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/temporal"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/fx"
 )
@@ -13,7 +14,14 @@ var Module = fx.Module("temporal",
 )
 
 func NewClient(lc fx.Lifecycle) (client.Client, error) {
-	c, err := client.Dial(client.Options{})
+	interceptors, err := temporal.ClientInterceptors()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.Dial(client.Options{
+		Interceptors: interceptors,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/saga/worker/app/app.go
+++ b/cmd/saga/worker/app/app.go
@@ -2,9 +2,9 @@ package app
 
 import (
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/worker/app/temporal"
-	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/worker/app/tracing"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/saga/worker/app/worker"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/logging"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/tracing"
 	"go.uber.org/fx"
 )
 
@@ -12,5 +12,7 @@ var Module = fx.Options(
 	temporal.Module,
 	logging.Module,
 	worker.Module,
-	tracing.Module,
+	tracing.CreateModule(tracing.ModuleOptions{
+		ServiceName: "temporal-worker",
+	}),
 )

--- a/cmd/saga/worker/app/temporal/temporal.go
+++ b/cmd/saga/worker/app/temporal/temporal.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"context"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/temporal"
 	"go.temporal.io/sdk/client"
 	"go.uber.org/fx"
 )
@@ -13,7 +14,14 @@ var Module = fx.Module("temporal",
 )
 
 func NewClient(lc fx.Lifecycle) (client.Client, error) {
-	c, err := client.Dial(client.Options{})
+	interceptors, err := temporal.ClientInterceptors()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.Dial(client.Options{
+		Interceptors: interceptors,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/saga/worker/app/worker/worker.go
+++ b/cmd/saga/worker/app/worker/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/saga"
-	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/temporal"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.temporal.io/sdk/client"
@@ -78,11 +77,6 @@ func NewConnToProfile() (*grpc.ClientConn, error) {
 }
 
 func NewWorker(lc fx.Lifecycle, c client.Client, ctrl *saga.Controller) (*worker.Worker, error) {
-	interceptors, err := temporal.WorkerInterceptors()
-	if err != nil {
-		return nil, err
-	}
-
 	// This worker hosts both Workflow and Activity functions
 	w := worker.New(c, saga.CreateLicenseTaskQueue, worker.Options{
 		// worker.Start() only return errors on start, so we need to catch
@@ -90,7 +84,6 @@ func NewWorker(lc fx.Lifecycle, c client.Client, ctrl *saga.Controller) (*worker
 		OnFatalError: func(err error) {
 			logrus.WithError(err).Error("Worker failed!")
 		},
-		Interceptors: interceptors,
 	})
 
 	w.RegisterWorkflow(saga.CreateLicense)

--- a/cmd/saga/worker/app/worker/worker.go
+++ b/cmd/saga/worker/app/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/saga"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/interceptor"
@@ -56,19 +57,25 @@ func NewController(license, org, profile *grpc.ClientConn) *saga.Controller {
 func NewConnToLicense() (*grpc.ClientConn, error) {
 	addr := fmt.Sprintf("localhost:%d", servicePortLicense)
 	return grpc.Dial(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+	)
 }
 
 func NewConnToOrg() (*grpc.ClientConn, error) {
 	addr := fmt.Sprintf("localhost:%d", servicePortOrg)
 	return grpc.Dial(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+	)
 }
 
 func NewConnToProfile() (*grpc.ClientConn, error) {
 	addr := fmt.Sprintf("localhost:%d", servicePortProfile)
 	return grpc.Dial(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
+	)
 }
 
 func NewWorker(lc fx.Lifecycle, c client.Client, ctrl *saga.Controller) (*worker.Worker, error) {

--- a/cmd/svc/license/app/app.go
+++ b/cmd/svc/license/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/svc/license/app/service"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/logging"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/rand"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/tracing"
 	"go.uber.org/fx"
 )
 
@@ -13,4 +14,7 @@ var Module = fx.Options(
 	logging.Module,
 	service.Module,
 	rand.Module,
+	tracing.CreateModule(tracing.ModuleOptions{
+		ServiceName: "license-svc",
+	}),
 )

--- a/cmd/svc/org/app/app.go
+++ b/cmd/svc/org/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/svc/org/app/service"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/logging"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/rand"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/tracing"
 	"go.uber.org/fx"
 )
 
@@ -13,4 +14,7 @@ var Module = fx.Options(
 	logging.Module,
 	service.Module,
 	rand.Module,
+	tracing.CreateModule(tracing.ModuleOptions{
+		ServiceName: "org-svc",
+	}),
 )

--- a/cmd/svc/profile/app/app.go
+++ b/cmd/svc/profile/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kevinmichaelchen/temporal-saga-grpc/cmd/svc/profile/app/service"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/logging"
 	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/rand"
+	"github.com/kevinmichaelchen/temporal-saga-grpc/pkg/fxmod/tracing"
 	"go.uber.org/fx"
 )
 
@@ -13,4 +14,7 @@ var Module = fx.Options(
 	logging.Module,
 	service.Module,
 	rand.Module,
+	tracing.CreateModule(tracing.ModuleOptions{
+		ServiceName: "profile-svc",
+	}),
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sethvargo/go-envconfig v0.8.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4
 	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1
@@ -16,7 +17,7 @@ require (
 	go.temporal.io/sdk/contrib/opentelemetry v0.2.0
 	go.uber.org/fx v1.18.2
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
-	google.golang.org/grpc v1.49.0
+	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -133,6 +134,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4 h1:PRXhsszxTt5bbPriTjmaweWUsAnJYeWBhUMLRetUgBU=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4/go.mod h1:05eWWy6ZWzmpeImD3UowLTB3VjDMU1yxQ+ENuVWDM3c=
 go.opentelemetry.io/otel v1.2.0/go.mod h1:aT17Fk0Z1Nor9e0uisf98LrntPGMnk4frBO9+dkf69I=
 go.opentelemetry.io/otel v1.11.1 h1:4WLLAmcfkmDk2ukNXJyq3/kiz/3UzCaYq6PskJsaou4=
 go.opentelemetry.io/otel v1.11.1/go.mod h1:1nNhXBbWSD0nsL38H6btgnFN2k4i0sNLHNNMZMSbUGE=
@@ -206,6 +209,7 @@ golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c h1:yKufUcDwucU5urd+50/Opbt4AYpqthk7wHpHok8f1lo=
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -267,6 +271,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -287,8 +292,9 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
+google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
+google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/connect/extract.go
+++ b/pkg/connect/extract.go
@@ -1,0 +1,106 @@
+package connect
+
+import (
+	"context"
+	"github.com/bufbuild/connect-go"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	grpc_codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"net"
+	"net/http"
+	"strings"
+)
+
+func extract(ctx context.Context, propagators propagation.TextMapPropagator, req connect.AnyRequest) context.Context {
+	return propagators.Extract(ctx, &metadataSupplier{
+		headers: req.Header(),
+	})
+}
+
+type metadataSupplier struct {
+	headers http.Header
+}
+
+// assert that metadataSupplier implements the TextMapCarrier interface.
+var _ propagation.TextMapCarrier = &metadataSupplier{}
+
+func (s *metadataSupplier) Get(key string) string {
+	return s.headers.Get(key)
+}
+
+func (s *metadataSupplier) Set(key string, value string) {
+	s.headers.Set(key, value)
+}
+
+func (s *metadataSupplier) Keys() []string {
+	out := make([]string, 0, len(s.headers))
+	for key := range s.headers {
+		out = append(out, key)
+	}
+	return out
+}
+
+// peerFromCtx returns a peer address from a context, if one exists.
+func peerFromCtx(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return ""
+	}
+	return p.Addr.String()
+}
+
+// spanInfo returns a span name and all appropriate attributes from the gRPC
+// method and peer address.
+func spanInfo(fullMethod, peerAddress string) (string, []attribute.KeyValue) {
+	attrs := []attribute.KeyValue{otelgrpc.RPCSystemGRPC}
+	name, mAttrs := ParseFullMethod(fullMethod)
+	attrs = append(attrs, mAttrs...)
+	attrs = append(attrs, peerAttr(peerAddress)...)
+	return name, attrs
+}
+
+// peerAttr returns attributes about the peer address.
+func peerAttr(addr string) []attribute.KeyValue {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return []attribute.KeyValue(nil)
+	}
+
+	if host == "" {
+		host = "127.0.0.1"
+	}
+
+	return []attribute.KeyValue{
+		semconv.NetPeerIPKey.String(host),
+		semconv.NetPeerPortKey.String(port),
+	}
+}
+
+// ParseFullMethod returns a span name following the OpenTelemetry semantic
+// conventions as well as all applicable span attribute.KeyValue attributes based
+// on a gRPC's FullMethod.
+func ParseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
+	name := strings.TrimLeft(fullMethod, "/")
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		// Invalid format, does not follow `/package.service/method`.
+		return name, []attribute.KeyValue(nil)
+	}
+
+	var attrs []attribute.KeyValue
+	if service := parts[0]; service != "" {
+		attrs = append(attrs, semconv.RPCServiceKey.String(service))
+	}
+	if method := parts[1]; method != "" {
+		attrs = append(attrs, semconv.RPCMethodKey.String(method))
+	}
+	return name, attrs
+}
+
+// statusCodeAttr returns status code attribute based on given gRPC code.
+func statusCodeAttr(c grpc_codes.Code) attribute.KeyValue {
+	return otelgrpc.GRPCStatusCodeKey.Int64(int64(c))
+}

--- a/pkg/connect/interceptors.go
+++ b/pkg/connect/interceptors.go
@@ -19,7 +19,10 @@ func connectInterceptorForSpan() connect.UnaryInterceptorFunc {
 			req connect.AnyRequest,
 		) (connect.AnyResponse, error) {
 			name := req.Spec().Procedure
+
 			tr := otel.Tracer("")
+
+			// Create a new span
 			ctx, span := tr.Start(ctx, name)
 			defer span.End()
 

--- a/pkg/connect/interceptors.go
+++ b/pkg/connect/interceptors.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"github.com/bufbuild/connect-go"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	grpc_codes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func UnaryInterceptors() []connect.Interceptor {
@@ -12,21 +16,43 @@ func UnaryInterceptors() []connect.Interceptor {
 	}
 }
 
+// TODO this can go away eventually when we get an official interceptor:
+// https://github.com/bufbuild/connect-go/issues/344
+// For now, we're inspired by:
+// https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/google.golang.org/grpc/otelgrpc/v0.36.4/instrumentation/google.golang.org/grpc/otelgrpc/interceptor.go#L307
 func connectInterceptorForSpan() connect.UnaryInterceptorFunc {
 	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
 		return connect.UnaryFunc(func(
 			ctx context.Context,
 			req connect.AnyRequest,
 		) (connect.AnyResponse, error) {
-			name := req.Spec().Procedure
+			fullMethod := req.Spec().Procedure // e.g., "/acme.foo.v1.FooService/Bar"
 
 			tr := otel.Tracer("")
 
+			ctx = extract(ctx, otel.GetTextMapPropagator(), req)
+
+			name, attr := spanInfo(fullMethod, peerFromCtx(ctx))
+
 			// Create a new span
-			ctx, span := tr.Start(ctx, name)
+			ctx, span := tr.Start(
+				trace.ContextWithRemoteSpanContext(ctx, trace.SpanContextFromContext(ctx)),
+				name,
+				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithAttributes(attr...),
+			)
 			defer span.End()
 
-			return next(ctx, req)
+			resp, err := next(ctx, req)
+			if err != nil {
+				s, _ := status.FromError(err)
+				span.SetStatus(codes.Error, s.Message())
+				span.SetAttributes(statusCodeAttr(s.Code()))
+			} else {
+				span.SetAttributes(statusCodeAttr(grpc_codes.OK))
+			}
+
+			return resp, err
 		})
 	}
 	return connect.UnaryInterceptorFunc(interceptor)

--- a/pkg/fxmod/tracing/tracing.go
+++ b/pkg/fxmod/tracing/tracing.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.uber.org/fx"
 	"log"
 	"time"
@@ -57,6 +58,9 @@ func Register(tp *tracesdk.TracerProvider) {
 	// Register our TracerProvider as the global so any imported
 	// instrumentation in the future will default to using it.
 	otel.SetTracerProvider(tp)
+
+	// Set the same Trace Propagator that Temporal uses by default
+	otel.SetTextMapPropagator(opentelemetry.DefaultTextMapPropagator)
 }
 
 // NewTracerProvider returns an OpenTelemetry TracerProvider configured to use

--- a/pkg/temporal/interceptors.go
+++ b/pkg/temporal/interceptors.go
@@ -7,27 +7,11 @@ import (
 )
 
 func ClientInterceptors() ([]interceptor.ClientInterceptor, error) {
-	i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
-		//TextMapPropagator: otel.GetTextMapPropagator(),
-	})
+	i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
 	}
 	return []interceptor.ClientInterceptor{
 		i,
 	}, nil
-	//return nil, nil
-}
-
-func WorkerInterceptors() ([]interceptor.WorkerInterceptor, error) {
-	//i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
-	//	TextMapPropagator: otel.GetTextMapPropagator(),
-	//})
-	//if err != nil {
-	//	return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
-	//}
-	//return []interceptor.WorkerInterceptor{
-	//	i,
-	//}, nil
-	return nil, nil
 }

--- a/pkg/temporal/interceptors.go
+++ b/pkg/temporal/interceptors.go
@@ -1,20 +1,22 @@
 package temporal
 
 import (
+	"fmt"
+	"go.temporal.io/sdk/contrib/opentelemetry"
 	"go.temporal.io/sdk/interceptor"
 )
 
 func ClientInterceptors() ([]interceptor.ClientInterceptor, error) {
-	//i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
-	//	TextMapPropagator: otel.GetTextMapPropagator(),
-	//})
-	//if err != nil {
-	//	return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
-	//}
-	//return []interceptor.ClientInterceptor{
-	//	i,
-	//}, nil
-	return nil, nil
+	i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
+		//TextMapPropagator: otel.GetTextMapPropagator(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
+	}
+	return []interceptor.ClientInterceptor{
+		i,
+	}, nil
+	//return nil, nil
 }
 
 func WorkerInterceptors() ([]interceptor.WorkerInterceptor, error) {

--- a/pkg/temporal/interceptors.go
+++ b/pkg/temporal/interceptors.go
@@ -1,0 +1,31 @@
+package temporal
+
+import (
+	"go.temporal.io/sdk/interceptor"
+)
+
+func ClientInterceptors() ([]interceptor.ClientInterceptor, error) {
+	//i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
+	//	TextMapPropagator: otel.GetTextMapPropagator(),
+	//})
+	//if err != nil {
+	//	return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
+	//}
+	//return []interceptor.ClientInterceptor{
+	//	i,
+	//}, nil
+	return nil, nil
+}
+
+func WorkerInterceptors() ([]interceptor.WorkerInterceptor, error) {
+	//i, err := opentelemetry.NewTracingInterceptor(opentelemetry.TracerOptions{
+	//	TextMapPropagator: otel.GetTextMapPropagator(),
+	//})
+	//if err != nil {
+	//	return nil, fmt.Errorf("failed to create OTEL tracing interceptor: %w", err)
+	//}
+	//return []interceptor.WorkerInterceptor{
+	//	i,
+	//}, nil
+	return nil, nil
+}


### PR DESCRIPTION
Related to #10. Previously, we were seeing nested spans for all Temporal activity, but not for any of our own gRPC clients and servers.

- [x] instrument all gRPC clients with [`otelgrpc`](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc#UnaryClientInterceptor)
- [x] instrument all gRPC servers (previously, our Connect interceptor was creating a span, but it wasn't doing _extraction_ properly; this was causing each individual gRPC endpoint to show up as a separate trace in Jaeger UI; the fix was to basically copy otelgrpc's [UnaryServerInterceptor](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc#UnaryServerInterceptor); pretty soon we'll have [official Connect middleware](https://github.com/bufbuild/connect-go/issues/344) for OTeL)
- [x] add Jaeger collection/export to all services
- [x] Don't apply worker interceptors when they're already on the Temporal client

### Setting worker interceptor was causing issues
From the [docs](https://pkg.go.dev/go.temporal.io/sdk@v1.17.0/internal#ClientOptions):
> Interceptors to apply to some calls of the client. Earlier interceptors wrap later interceptors.
>
> Any interceptors that also implement Interceptor (meaning they implement `WorkerInterceptor` in addition to `ClientInterceptor`) will be used for worker interception as well. When worker interceptors are here and in worker options, the ones here wrap the ones in worker options. **The same interceptor should not be set here and in worker options.**