### PR TITLE
feat: Integrate Tailcall with OpenTelemetry

### DIFF
--- a/cmd/saga/start/service/service.go
+++ b/cmd/saga/start/service/service.go
@@ -38,6 +38,9 @@ func (s *Service) CreateOnboardingWorkflow(
 	ctx context.Context,
 	req *connect.Request[temporalPB.CreateOnboardingWorkflowRequest],
 ) (*connect.Response[temporalPB.CreateOnboardingWorkflowResponse], error) {
+
+	log.Info("received request", "headers", req.Header())
+
 	temporalClient := s.client
 
 	// Validate the request

--- a/tailcall/server.graphql
+++ b/tailcall/server.graphql
@@ -9,7 +9,16 @@ schema
   )
 
   # Specify a base url for all HTTP requests.
-  @upstream(timeout: 5) {
+  @upstream(timeout: 5)
+
+  @telemetry(
+    export: {
+      otlp: {
+        url: "http://localhost:4318"
+      }
+    }
+  ) {
+
   query: Query
   mutation: Mutation
 }

--- a/tailcall/server.graphql
+++ b/tailcall/server.graphql
@@ -14,7 +14,7 @@ schema
   @telemetry(
     export: {
       otlp: {
-        url: "http://localhost:4318"
+        url: "http://localhost:4317"
       }
     }
   ) {

--- a/taskfiles/run.yml
+++ b/taskfiles/run.yml
@@ -21,7 +21,7 @@ tasks:
     cmds:
       - pkgx killport 8000
       - |
-        pkgx tailcall start \
+        pkgx tailcall@latest start \
           ./tailcall/server.graphql \
           ./tailcall/org.graphql \
           ./tailcall/profile.graphql \


### PR DESCRIPTION
```
# step 1 - start up servers
make

# step 2 - start tailcall
task run:tailcall

# step 3 - start docs
(cd docs && bun install && bun dev)
```

Run [this GraphQL mutation](http://localhost:4321/temporal-saga-grpc/reference/temporal/) in the [GraphQL Playground](http://127.0.0.1:8000/).

Tailcall will export telemetry via gRPC to the local OTel Collector's port 4317. A trace for `tailcall` will appear in [Jaeger](http://localhost:16686).